### PR TITLE
redirected createOrders to sendOrder for OrderServiceHandler V2_0 and V2_1

### DIFF
--- a/src/main/java/com/intershop/oms/test/servicehandler/orderservice/v2_0/OMSOrderServiceHandlerV2.java
+++ b/src/main/java/com/intershop/oms/test/servicehandler/orderservice/v2_0/OMSOrderServiceHandlerV2.java
@@ -82,9 +82,14 @@ class OMSOrderServiceHandlerV2 extends RESTServiceHandler
     }
 
     @Override
+    //this just calls sendOrder(OMSOrder, int) in order to be upwards-compatible with tests from OrderServiceSpec
     public List<OMSOrder> createOrders(List<OMSOrder> omsOrders, Integer targetState) throws ApiException
     {
-        throw new RuntimeException("Method not supported for version < 2.2!");
+        for (OMSOrder omsOrder : omsOrders)
+        {
+            sendOrder(omsOrder, targetState);
+        }
+        return omsOrders;
     }
 
     @Override

--- a/src/main/java/com/intershop/oms/test/servicehandler/orderservice/v2_0/OMSOrderServiceHandlerV2.java
+++ b/src/main/java/com/intershop/oms/test/servicehandler/orderservice/v2_0/OMSOrderServiceHandlerV2.java
@@ -1,5 +1,6 @@
 package com.intershop.oms.test.servicehandler.orderservice.v2_0;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -55,6 +56,36 @@ class OMSOrderServiceHandlerV2 extends RESTServiceHandler
     }
 
     /**
+     * sends a list of orders
+     *
+     * @param host
+     * @param port
+     * @param order
+     * @param expectedEndState
+     *            wait for the order to be in the given state before returning
+     *
+     * @return the orderIds
+     * @throws ApiException
+     */
+    public List<Long> sendOrders(List<OMSOrder> omsOrders, int expectedEndState) throws ApiException
+    {
+        List<Long> omsOrderCreatedIds = new ArrayList<Long>();
+
+        for (OMSOrder omsOrder: omsOrders)
+        {
+            Long orderId = sendOrder(omsOrder);
+            omsOrderCreatedIds.add(orderId);
+        }
+        
+        for (Long orderId: omsOrderCreatedIds)
+        {
+            assert dbHandler.waitForOrderState(orderId, expectedEndState);
+        }
+
+        return omsOrderCreatedIds;
+    }
+    
+    /**
      * sends an order
      *
      * @param host
@@ -82,13 +113,10 @@ class OMSOrderServiceHandlerV2 extends RESTServiceHandler
     }
 
     @Override
-    //this just calls sendOrder(OMSOrder, int) in order to be upwards-compatible with tests from OrderServiceSpec
+    //this just calls sendOrders(List<OMSOrder>, int) in order to be upwards-compatible with tests from OrderServiceSpec
     public List<OMSOrder> createOrders(List<OMSOrder> omsOrders, Integer targetState) throws ApiException
     {
-        for (OMSOrder omsOrder : omsOrders)
-        {
-            sendOrder(omsOrder, targetState);
-        }
+        sendOrders(omsOrders, targetState);
         return omsOrders;
     }
 

--- a/src/main/java/com/intershop/oms/test/servicehandler/orderservice/v2_1/OMSOrderServiceHandlerV2_1.java
+++ b/src/main/java/com/intershop/oms/test/servicehandler/orderservice/v2_1/OMSOrderServiceHandlerV2_1.java
@@ -1,5 +1,6 @@
 package com.intershop.oms.test.servicehandler.orderservice.v2_1;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -11,6 +12,7 @@ import com.intershop.oms.rest.order.v2_1.api.OrderApi;
 import com.intershop.oms.rest.order.v2_1.model.Order;
 import com.intershop.oms.rest.shared.ApiException;
 import com.intershop.oms.rest.shared.ApiResponse;
+import com.intershop.oms.test.businessobject.OMSShop;
 import com.intershop.oms.test.businessobject.order.OMSChangeRequest;
 import com.intershop.oms.test.businessobject.order.OMSOrder;
 import com.intershop.oms.test.configuration.ServiceConfiguration;
@@ -82,9 +84,14 @@ class OMSOrderServiceHandlerV2_1 extends RESTServiceHandler
     }
 
     @Override
+    //this just calls sendOrder(OMSOrder, int) in order to be upwards-compatible with tests from OrderServiceSpec
     public List<OMSOrder> createOrders(List<OMSOrder> omsOrders, Integer targetState) throws ApiException
     {
-        throw new RuntimeException("Method not supported for version < 2.2!");
+        for (OMSOrder omsOrder : omsOrders)
+        {
+            sendOrder(omsOrder, targetState);
+        }
+        return omsOrders;
     }
 
     @Override


### PR DESCRIPTION
to be upwards-compatible with OrderServiceSpec tests