### PR TITLE
bug: NPE on not set properties (#87)

### DIFF
--- a/src/main/java/com/intershop/oms/test/businessobject/rma/OMSReturnRequest.java
+++ b/src/main/java/com/intershop/oms/test/businessobject/rma/OMSReturnRequest.java
@@ -29,7 +29,7 @@ public class OMSReturnRequest extends OMSBusinessObject
     private List<OMSReturnRequestPosition> positions = new ArrayList<>();
     private OMSPickupAddress pickupAddress;
     private List<OMSContactPerson> contactPersons = new ArrayList<>();
-    private List<OMSCustomAttribute> customAttributes = new ArrayList<>();
+    private List<OMSCustomAttribute> customAttributes = null;
     private Long id;
     private Date creationDate;
     private String shopOrderNumber;
@@ -69,7 +69,7 @@ public class OMSReturnRequest extends OMSBusinessObject
             return String.valueOf(value);
         }
     }
-    
+
     public enum BusinessStatusEnum
     {
         ACCEPTED("ACCEPTED"),

--- a/src/main/java/com/intershop/oms/test/servicehandler/rmaservice/v2_12/mapping/CustomAttributesMapper.java
+++ b/src/main/java/com/intershop/oms/test/servicehandler/rmaservice/v2_12/mapping/CustomAttributesMapper.java
@@ -24,6 +24,11 @@ public interface CustomAttributesMapper
 
     default List<ReadCustomAttribute> toApiReadCustomAttributes(Map<String,String> customAttributes)
     {
+        if (customAttributes == null)
+        {
+            return null;
+        }
+
         return customAttributes.entrySet().stream().map( in ->
             {
                 ReadCustomAttribute wca = new ReadCustomAttribute();
@@ -38,9 +43,14 @@ public interface CustomAttributesMapper
         return customAttributes.stream()
             .collect(Collectors.toMap(WriteCustomAttribute::getKey, WriteCustomAttribute::getValue, (t, u) -> t, HashMap::new));
     }
-    
+
     default List<WriteCustomAttribute> toApiWriteCustomAttributes(Map<String, String> customAttributes)
     {
+        if (customAttributes == null)
+        {
+            return null;
+        }
+
         return customAttributes.entrySet().stream().map( in ->
             {
                 WriteCustomAttribute wca = new WriteCustomAttribute();


### PR DESCRIPTION
it must be possible to send requests without a properties list by setting the field to null